### PR TITLE
refactor: notion api calls

### DIFF
--- a/lib/notion.js
+++ b/lib/notion.js
@@ -1,0 +1,25 @@
+import { Client } from "@notionhq/client";
+
+const notion = new Client({
+  auth: process.env.NOTION_API_KEY,
+});
+
+export const getDatabase = async (databaseId) => {
+  const response = await notion.databases.query({
+    database_id: databaseId,
+  });
+  return response.results;
+};
+
+export const getPage = async (pageId) => {
+  const response = await notion.pages.retrieve({ page_id: pageId });
+  return response;
+};
+
+export const getBlocks = async (blockId) => {
+  const response = await notion.blocks.children.list({
+    block_id: blockId,
+    page_size: 50,
+  });
+  return response.results;
+};

--- a/pages/campaigns/index.js
+++ b/pages/campaigns/index.js
@@ -1,8 +1,12 @@
 import styles from "../../styles/Home.module.css";
-import { Client } from "@notionhq/client";
+import { getDatabase } from "../../lib/notion";
 
-export default function CampaignBoard({ postings }) {
-  console.log(postings);
+const jobBoardDbId = process.env.NOTION_JOBBOARD_DATABASE_ID;
+const characterDBId = process.env.NOTION_CHARACTERS_DATABASE_ID;
+
+export default function CampaignBoard({ postings, characters }) {
+  // console.log(postings);
+  // console.log(characters);
 
   return (
     <div className={styles.container}>
@@ -12,6 +16,19 @@ export default function CampaignBoard({ postings }) {
           <div key={post.id} className={styles.card}>
             <h2>{post.properties.Name.title[0].text.content}</h2>
             <p>Status: {post.properties.Status.select.name}</p>
+            {post.properties.Characters.relation.map((player) => (
+              <span className={styles.cardlist} key={player.id}>
+                {
+                  characters[
+                    characters
+                      .map((element) => {
+                        return element.id;
+                      })
+                      .indexOf(player.id)
+                  ].properties.Name.title[0].plain_text
+                }
+              </span>
+            ))}
           </div>
         ))}
       </main>
@@ -20,15 +37,14 @@ export default function CampaignBoard({ postings }) {
 }
 
 export async function getStaticProps() {
-  const notion = new Client({ auth: process.env.NOTION_API_KEY });
-  const response = await notion.databases.query({
-    database_id: process.env.NOTION_JOBBOARD_DATABASE_ID,
-  });
-
+  console.log(jobBoardDbId);
+  const jobBoard = await getDatabase(jobBoardDbId);
+  const characters = await getDatabase(characterDBId);
   return {
     props: {
-      postings: response.results,
+      postings: jobBoard,
+      characters: characters,
     },
-    revalidate: 60,
+    revalidate: 20,
   };
 }


### PR DESCRIPTION
refactored notion api calls to be housed inside the lib directory to reduce the amount of repeated code. One can import the function they want to use into their component and then call based on the database / page ids

closes #7