### PR TITLE
fix: fontawesome rendering

### DIFF
--- a/pages/_app.js
+++ b/pages/_app.js
@@ -1,7 +1,11 @@
-import '../styles/globals.css'
+import "@fortawesome/fontawesome-svg-core/styles.css";
+import { config } from "@fortawesome/fontawesome-svg-core";
+config.autoAddCss = false;
+
+import "../styles/globals.css";
 
 function MyApp({ Component, pageProps }) {
-  return <Component {...pageProps} />
+  return <Component {...pageProps} />;
 }
 
-export default MyApp
+export default MyApp;


### PR DESCRIPTION
fontAwesome rendering on different lines and different sizes

fix was to disable autoadding of css in the configuration of the fontAwesome component

closes #38